### PR TITLE
Fixed 'replace font' issues in sketch 3.3.2

### DIFF
--- a/Replace Font.sketchplugin
+++ b/Replace Font.sketchplugin
@@ -1,7 +1,10 @@
 // Change font
 // This plugin changes the font family of all text layers in the document
 
-var font_name = [doc askForUserInput:"Font name:" initialValue:"Arial"]
+var selection = context.selection
+var doc = context.doc
+
+var font_name = [doc askForUserInput:"Font name:" initialValue:""]
 
 function check_layer(layer){
   var klass = [layer className]


### PR DESCRIPTION
I was having trouble getting this plugin to run. I have not used the others yet.  

_Here's the things I changed to resolve the issues I was having:_
- plugin was not able to find 'doc' and 'selection', variables I pulled those in from context
- plugin had no effect when using the 'initialValue' on font_name.  If I manually fill that field out, everything executed fine. Perhaps this is a sketch bug,  but it seems miss leading to give that an initial value that isn't blank at the moment